### PR TITLE
Run tests and fix imports

### DIFF
--- a/tradingview_scraper/symbols/news.py
+++ b/tradingview_scraper/symbols/news.py
@@ -5,7 +5,7 @@ import json
 
 from bs4 import BeautifulSoup
 import requests
-import pkg_resources
+from importlib import resources
 
 
 from tradingview_scraper.symbols.utils import save_csv_file, save_json_file, generate_user_agent
@@ -298,7 +298,7 @@ class NewsScraper:
         Raises:
             IOError: If there is an error reading the file.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/languages.json')
+        path = resources.files('tradingview_scraper').joinpath('data/languages.json')
         if not os.path.exists(path):
             print(f"[ERROR] Languages file not found at {path}.")
             return []
@@ -320,7 +320,7 @@ class NewsScraper:
         Raises:
             IOError: If there is an error reading the file.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/exchanges.txt')
+        path = resources.files('tradingview_scraper').joinpath('data/exchanges.txt')
         if not os.path.exists(path):
             print(f"[ERROR] Exchanges file not found at {path}.")
             return []
@@ -342,7 +342,7 @@ class NewsScraper:
         Raises:
             IOError: If there is an error reading the file.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/news_providers.txt')
+        path = resources.files('tradingview_scraper').joinpath('data/news_providers.txt')
         if not os.path.exists(path):
             print(f"[ERROR] News provider file not found at {path}.")
             return []
@@ -364,7 +364,7 @@ class NewsScraper:
         Raises:
             IOError: If there is an error reading the file.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/areas.json')
+        path = resources.files('tradingview_scraper').joinpath('data/areas.json')
         if not os.path.exists(path):
             print(f"[ERROR] Areas file not found at {path}.")
             return []

--- a/tradingview_scraper/symbols/technicals.py
+++ b/tradingview_scraper/symbols/technicals.py
@@ -6,7 +6,7 @@ import json
 from typing import List, Optional
 
 import requests
-import pkg_resources
+from importlib import resources
 
 from tradingview_scraper.symbols.utils import generate_user_agent, save_json_file, save_csv_file
 
@@ -170,7 +170,7 @@ class Indicators:
         Returns:
             List[str]: A list of indicators loaded from the file. Returns an empty list if the file is not found.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/indicators.txt')
+        path = resources.files('tradingview_scraper').joinpath('data/indicators.txt')
         return self._load_file(path)
 
     def _load_exchanges(self) -> List[str]:
@@ -179,7 +179,7 @@ class Indicators:
         Returns:
             List[str]: A list of exchanges loaded from the file. Returns an empty list if the file is not found.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/exchanges.txt')
+        path = resources.files('tradingview_scraper').joinpath('data/exchanges.txt')
         return self._load_file(path)
     
     def _load_timeframes(self) -> dict:
@@ -188,7 +188,7 @@ class Indicators:
         Returns:
             dict: A dictionary of timeframes loaded from the file. Returns a dict with '1d' as default.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/timeframes.json')
+        path = resources.files('tradingview_scraper').joinpath('data/timeframes.json')
         if not os.path.exists(path):
             print(f"[ERROR] Timeframe file not found at {path}.")
             return {"1d": None}

--- a/tradingview_scraper/utils/ohlc_converter.py
+++ b/tradingview_scraper/utils/ohlc_converter.py
@@ -1,5 +1,5 @@
 from typing import List, Dict
-import pkg_resources
+from importlib import resources
 import json
 import os
 
@@ -122,7 +122,7 @@ class OHLCVConverter:
         Returns:
             dict: A dictionary of timeframes loaded from the file. Returns a dict with '1d' as default.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/timeframes.json')
+        path = resources.files('tradingview_scraper').joinpath('data/timeframes.json')
         if not os.path.exists(path):
             print(f"[ERROR] Timeframe file not found at {path}.")
             return {"1d": None}


### PR DESCRIPTION
## Summary
- remove dependency on pkg_resources by using importlib.resources
- adjust indicators, news and utils modules to work without setuptools

## Testing
- `pytest -q` *(fails: failed CONNECT via proxy status 403)*

------
https://chatgpt.com/codex/tasks/task_e_6844b66f801883308d3e03d9fa082c56