### PR TITLE
Add live crypto news script

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,8 +400,8 @@ res = calendar_scraper.scrape_dividends(
 ```
 
 ### 8. Live Crypto News Script
-Run the `crypto_news_live.py` script to print fresh headlines for the top
-10 cryptocurrencies.
+Run the `crypto_news_live.py` script to continuously print the latest
+headlines and body text for the top 10 cryptocurrencies.
 
 ```bash
 python crypto_news_live.py

--- a/README.md
+++ b/README.md
@@ -399,6 +399,14 @@ res = calendar_scraper.scrape_dividends(
   )
 ```
 
+### 8. Live Crypto News Script
+Run the `crypto_news_live.py` script to print fresh headlines for the top
+10 cryptocurrencies.
+
+```bash
+python crypto_news_live.py
+```
+
 ## Changes:
 - Release `0.4.9`:
   Add [documentation](https://mnwato.github.io/tradingview-scraper/)

--- a/crypto_news_live.py
+++ b/crypto_news_live.py
@@ -1,0 +1,39 @@
+import time
+from tradingview_scraper.symbols.news import NewsScraper
+
+TOP_10_CRYPTOS = [
+    ("BTCUSDT", "BINANCE"),
+    ("ETHUSDT", "BINANCE"),
+    ("BNBUSDT", "BINANCE"),
+    ("SOLUSDT", "BINANCE"),
+    ("XRPUSDT", "BINANCE"),
+    ("ADAUSDT", "BINANCE"),
+    ("DOGEUSDT", "BINANCE"),
+    ("TONUSDT", "BINANCE"),
+    ("AVAXUSDT", "BINANCE"),
+    ("TRXUSDT", "BINANCE"),
+]
+
+
+def main():
+    scraper = NewsScraper()
+    seen = {symbol: set() for symbol, _ in TOP_10_CRYPTOS}
+    while True:
+        for symbol, exchange in TOP_10_CRYPTOS:
+            try:
+                headlines = scraper.scrape_headlines(symbol=symbol, exchange=exchange, sort="latest")
+            except Exception as exc:
+                print(f"Error fetching news for {symbol}: {exc}")
+                continue
+            for item in headlines:
+                news_id = item.get("id")
+                if news_id and news_id not in seen[symbol]:
+                    seen[symbol].add(news_id)
+                    published = item.get("published_datetime", item.get("published"))
+                    title = item.get("title")
+                    print(f"{symbol} | {published} | {title}")
+        time.sleep(300)
+
+
+if __name__ == "__main__":
+    main()

--- a/crypto_news_live.py
+++ b/crypto_news_live.py
@@ -31,7 +31,21 @@ def main():
                     seen[symbol].add(news_id)
                     published = item.get("published_datetime", item.get("published"))
                     title = item.get("title")
-                    print(f"{symbol} | {published} | {title}")
+                    story_path = item.get("storyPath")
+                    body_text = ""
+                    if story_path:
+                        try:
+                            content = scraper.scrape_news_content(story_path=story_path)
+                            parts = [
+                                b.get("content", "")
+                                for b in content.get("body", [])
+                                if b.get("type") == "text"
+                            ]
+                            body_text = "\n".join(parts)
+                        except Exception as exc:
+                            body_text = f"Error fetching body: {exc}"
+
+                    print(f"{symbol} | {published} | {title}\n{body_text}")
         time.sleep(300)
 
 

--- a/tradingview_scraper/symbols/news.py
+++ b/tradingview_scraper/symbols/news.py
@@ -5,7 +5,12 @@ import json
 
 from bs4 import BeautifulSoup
 import requests
-import pkg_resources
+from importlib import resources
+
+
+def _resource_path(package: str, resource: str) -> str:
+    """Return the path to a resource bundled within the package."""
+    return str(resources.files(package).joinpath(resource))
 
 
 from tradingview_scraper.symbols.utils import save_csv_file, save_json_file, generate_user_agent
@@ -298,7 +303,7 @@ class NewsScraper:
         Raises:
             IOError: If there is an error reading the file.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/languages.json')
+        path = _resource_path('tradingview_scraper', 'data/languages.json')
         if not os.path.exists(path):
             print(f"[ERROR] Languages file not found at {path}.")
             return []
@@ -320,7 +325,7 @@ class NewsScraper:
         Raises:
             IOError: If there is an error reading the file.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/exchanges.txt')
+        path = _resource_path('tradingview_scraper', 'data/exchanges.txt')
         if not os.path.exists(path):
             print(f"[ERROR] Exchanges file not found at {path}.")
             return []
@@ -342,7 +347,7 @@ class NewsScraper:
         Raises:
             IOError: If there is an error reading the file.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/news_providers.txt')
+        path = _resource_path('tradingview_scraper', 'data/news_providers.txt')
         if not os.path.exists(path):
             print(f"[ERROR] News provider file not found at {path}.")
             return []
@@ -364,7 +369,7 @@ class NewsScraper:
         Raises:
             IOError: If there is an error reading the file.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/areas.json')
+        path = _resource_path('tradingview_scraper', 'data/areas.json')
         if not os.path.exists(path):
             print(f"[ERROR] Areas file not found at {path}.")
             return []

--- a/tradingview_scraper/symbols/technicals.py
+++ b/tradingview_scraper/symbols/technicals.py
@@ -6,7 +6,12 @@ import json
 from typing import List, Optional
 
 import requests
-import pkg_resources
+from importlib import resources
+
+
+def _resource_path(package: str, resource: str) -> str:
+    """Return the path to a resource bundled within the package."""
+    return str(resources.files(package).joinpath(resource))
 
 from tradingview_scraper.symbols.utils import generate_user_agent, save_json_file, save_csv_file
 
@@ -170,7 +175,7 @@ class Indicators:
         Returns:
             List[str]: A list of indicators loaded from the file. Returns an empty list if the file is not found.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/indicators.txt')
+        path = _resource_path('tradingview_scraper', 'data/indicators.txt')
         return self._load_file(path)
 
     def _load_exchanges(self) -> List[str]:
@@ -179,7 +184,7 @@ class Indicators:
         Returns:
             List[str]: A list of exchanges loaded from the file. Returns an empty list if the file is not found.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/exchanges.txt')
+        path = _resource_path('tradingview_scraper', 'data/exchanges.txt')
         return self._load_file(path)
     
     def _load_timeframes(self) -> dict:
@@ -188,7 +193,7 @@ class Indicators:
         Returns:
             dict: A dictionary of timeframes loaded from the file. Returns a dict with '1d' as default.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/timeframes.json')
+        path = _resource_path('tradingview_scraper', 'data/timeframes.json')
         if not os.path.exists(path):
             print(f"[ERROR] Timeframe file not found at {path}.")
             return {"1d": None}

--- a/tradingview_scraper/utils/ohlc_converter.py
+++ b/tradingview_scraper/utils/ohlc_converter.py
@@ -1,7 +1,12 @@
 from typing import List, Dict
-import pkg_resources
+from importlib import resources
 import json
 import os
+
+
+def _resource_path(package: str, resource: str) -> str:
+    """Return the path to a resource bundled within the package."""
+    return str(resources.files(package).joinpath(resource))
 
 
 class OHLCVConverter:
@@ -122,7 +127,7 @@ class OHLCVConverter:
         Returns:
             dict: A dictionary of timeframes loaded from the file. Returns a dict with '1d' as default.
         """
-        path = pkg_resources.resource_filename('tradingview_scraper', 'data/timeframes.json')
+        path = _resource_path('tradingview_scraper', 'data/timeframes.json')
         if not os.path.exists(path):
             print(f"[ERROR] Timeframe file not found at {path}.")
             return {"1d": None}


### PR DESCRIPTION
## Summary
- provide simple script `crypto_news_live.py` to continuously print top crypto headlines
- use `importlib.resources` instead of `pkg_resources`
- document how to run the new example

## Testing
- `pytest -q` *(fails: ProxyError and missing fixture 'mocker')*

------
https://chatgpt.com/codex/tasks/task_e_6844b86b335083308abeb48eed5ec386